### PR TITLE
Add Plugin.Maui.ScreenSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,6 @@ Here you can find a curated list of **awesome** .NET MAUI libraries and resource
 - [Plugin.Maui.AppRating](https://github.com/FabriBertani/Plugin.Maui.AppRating)
   [![GitHub stars](https://img.shields.io/github/stars/FabriBertani/Plugin.Maui.AppRating?style=flat-square)](https://github.com/FabriBertani/Plugin.Maui.AppRating)
   [![GitHub last-commit](https://img.shields.io/github/last-commit/FabriBertani/Plugin.Maui.AppRating?style=flat-square)](https://github.com/FabriBertani/Plugin.Maui.AppRating/commits) - An easy way to quickly add store rating reviews to your .Net MAUI app.
+- [Plugin.Maui.ScreenSecurity](https://github.com/FabriBertani/Plugin.Maui.ScreenSecurity)
+  [![GitHub stars](https://img.shields.io/github/stars/FabriBertani/Plugin.Maui.ScreenSecurity?style=flat-square)](https://github.com/FabriBertani/Plugin.Maui.ScreenSecurity)
+  [![GitHub last-commit](https://img.shields.io/github/last-commit/FabriBertani/Plugin.Maui.ScreenSecurity?style=flat-square)](https://github.com/FabriBertani/Plugin.Maui.ScreenSecurity/commits) - Safeguard your .NET MAUI app effortlessly by preventing content exposure, screenshots, and recordings with ease.


### PR DESCRIPTION
Added [Plugin.Maui.ScreenSecurity](https://github.com/FabriBertani/Plugin.Maui.ScreenSecurity) - Safeguard your .NET MAUI app effortlessly by preventing content exposure, screenshots, and recordings with ease. 

Closes #57